### PR TITLE
Command queues iterated by least recently issued

### DIFF
--- a/src/command_queue.h
+++ b/src/command_queue.h
@@ -40,6 +40,7 @@ class CommandQueue {
                          const CMDQueue& queue) const;
     Command GetFirstReadyInQueue(CMDQueue& queue) const;
     CMDQueue& GetNextQueue();
+    std::vector<int> GetQueueQueue();
     void GetRefQIndices(const Command& ref);
     void EraseRWCommand(const Command& cmd);
     Command PrepRefCmd(const CMDIterator& it, const Command& ref) const;
@@ -50,6 +51,7 @@ class CommandQueue {
     SimpleStats& simple_stats_;
 
     std::vector<CMDQueue> queues_;
+    std::vector<uint64_t> last_issued_;
 
     // Refresh related data structures
     std::unordered_set<int> ref_q_indices_;


### PR DESCRIPTION
This PR fixes an arbitration issue in the command queue where the round-robin arbitration between each bank queue can lead to certain banks being starved. This fix tracks the last cycle a command was issued from each queue and it prioritizes the command queue that was least recently serviced.