### PR TITLE
Bankgroup arbitration

### DIFF
--- a/src/blood_graph.cc
+++ b/src/blood_graph.cc
@@ -118,9 +118,9 @@ void BloodGraph::ClockTick() {
         if (cmd_queue_->QueueEmpty(i)) {
           PrintTrace(i, "nop");
         } else {
-          int ra = i / config_.banks;
-          int bg = (i % config_.banks) / config_.banks_per_group;
-          int ba = (i % config_.banks) % config_.banks_per_group;
+          int ra, bg, ba;
+          std::tie(ba, bg, ra) = cmd_queue_->GetBankBankgroupRankFromQueueIndex(i);
+          assert(cmd_queue_->GetQueueIndex(ra, bg, ba) == i);
           if (channel_state_->IsRowOpen(ra,bg,ba)) {
             // check if there is any row hit.
             int open_row = channel_state_->OpenRow(ra,bg,ba);

--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -147,6 +147,14 @@ CMDQueue& CommandQueue::GetNextQueue() {
     return queues_[queue_idx_];
 }
 
+std::tuple<int, int, int> CommandQueue::GetBankBankgroupRankFromQueueIndex(int queue_index) const {
+    int rank = queue_index % config_.ranks;
+    int bgba = queue_index / config_.ranks;
+    int bankgroup = bgba % config_.bankgroups;
+    int bank = bgba / config_.bankgroups;
+    return std::make_tuple(bank, bankgroup, rank);
+}
+
 void CommandQueue::GetRefQIndices(const Command& ref) {
     if (ref.cmd_type == CommandType::REFRESH) {
         if (queue_structure_ == QueueStructure::PER_BANK) {

--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -177,10 +177,7 @@ int CommandQueue::GetQueueIndex(int rank, int bankgroup, int bank) const {
     if (queue_structure_ == QueueStructure::PER_RANK) {
         return rank;
     } else {
-        // multi-level round-robin arbitration
-        // ba 0 ... ba n   ba 0 ... ba n   ba 0 ... ba n   ba 0 ... ba m
-        //      bg0     ...     bg1             bg0     ...     bg1
-        //              ra0                             ra1
+        // alternates ranks, then bank groups, then banks
         return bank * config_.bankgroups * config_.ranks
             +  bankgroup * config_.ranks
             +  rank;

--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -188,8 +188,13 @@ int CommandQueue::GetQueueIndex(int rank, int bankgroup, int bank) const {
     if (queue_structure_ == QueueStructure::PER_RANK) {
         return rank;
     } else {
-        return rank * config_.banks + bankgroup * config_.banks_per_group +
-               bank;
+        // multi-level round-robin arbitration
+        // ba 0 ... ba n   ba 0 ... ba n   ba 0 ... ba n   ba 0 ... ba m
+        //      bg0     ...     bg1             bg0     ...     bg1
+        //              ra0                             ra1
+        return bank * config_.bankgroups * config_.ranks
+            +  bankgroup * config_.ranks
+            +  rank;
     }
 }
 

--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -31,27 +31,11 @@ CommandQueue::CommandQueue(int channel_id, const Config& config,
         cmd_queue.reserve(config_.cmd_queue_size);
         queues_.push_back(cmd_queue);
     }
-
-    last_issued_.resize(queues_.size(), 0);
-}
-
-std::vector<int> CommandQueue::GetQueueQueue() {
-    std::vector<int> qq(queues_.size());
-    for (int i = 0; i < queues_.size(); i++)
-        qq[i] = i;
-
-    std::sort(qq.begin(), qq.end(), [this](const int& first, const int& second) {
-            return this->last_issued_[first] < this->last_issued_[second];
-        });
-
-    return qq;
 }
 
 Command CommandQueue::GetCommandToIssue() {
-    auto qqueue = GetQueueQueue();
-    for (int qidx : qqueue) {
-        queue_idx_ = qidx;
-        auto& queue = queues_[queue_idx_];
+    for (int i = 0; i < num_queues_; i++) {
+        auto& queue = GetNextQueue();
         // if we're refresing, skip the command queues that are involved
         if (is_in_ref_) {
             if (ref_q_indices_.find(queue_idx_) != ref_q_indices_.end()) {
@@ -63,9 +47,6 @@ Command CommandQueue::GetCommandToIssue() {
             if (cmd.IsReadWrite()) {
                 EraseRWCommand(cmd);
             }
-            // update the last time a command from this
-            // queue was issued
-            last_issued_[queue_idx_] = clk_;
             return cmd;
         }
     }

--- a/src/command_queue.h
+++ b/src/command_queue.h
@@ -40,7 +40,6 @@ class CommandQueue {
                          const CMDQueue& queue) const;
     Command GetFirstReadyInQueue(CMDQueue& queue) const;
     CMDQueue& GetNextQueue();
-    std::vector<int> GetQueueQueue();
     void GetRefQIndices(const Command& ref);
     void EraseRWCommand(const Command& cmd);
     Command PrepRefCmd(const CMDIterator& it, const Command& ref) const;
@@ -51,7 +50,6 @@ class CommandQueue {
     SimpleStats& simple_stats_;
 
     std::vector<CMDQueue> queues_;
-    std::vector<uint64_t> last_issued_;
 
     // Refresh related data structures
     std::unordered_set<int> ref_q_indices_;

--- a/src/command_queue.h
+++ b/src/command_queue.h
@@ -3,6 +3,7 @@
 
 #include <unordered_set>
 #include <vector>
+#include <tuple>
 #include "channel_state.h"
 #include "common.h"
 #include "configuration.h"
@@ -27,6 +28,7 @@ class CommandQueue {
 
     bool QueueEmpty(int q_idx) const;
     int GetQueueIndex(int rank, int bankgroup, int bank) const;
+    std::tuple<int, int, int> GetBankBankgroupRankFromQueueIndex(int queue_index) const;    
     int QueueUsage() const;
     std::vector<bool> rank_q_empty;
 


### PR DESCRIPTION
As it was originally written, the order for arbitration is the following:
ba 0 bg 0, ba 1 bg 0, ba 2 bg 0, ba 3 bg 0, ba0 bg1, etc. This can cause a pathology where ba 0 bg 0 can starve out the other banks in its group because of CCDL. Basically, ba 1, bg 0 cannot issue a command the cycle after ba 0 bg 0 issues a command. If ba 0 bg 0 always has a command, ba 1 bg 0 will starve. 
This pr changes the order of arbitration to this: ba 0 bg 0, ba 0 bg 1, ba 0 bg 2, ba 0 bg3, ba 1 bg 0, etc. This allows CCDL to expire before checking ba1 bg0.
Implementing this was as simple as how we calculate queue_index from bank, bankgroup, and rank.